### PR TITLE
Cron imports

### DIFF
--- a/app/Controllers/AdminController.php
+++ b/app/Controllers/AdminController.php
@@ -11,7 +11,7 @@ class AdminController {
   public function index() {
     $query = array(
       'post_type' => 'post',
-      'meta_key'  => 'catfish-importer_date-updated',
+      'meta_key'  => 'catfish_importer_date_updated',
       'posts_per_page' => 50,
       'orderby' => 'meta_value_num',
       'order' => 'DESC',

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -14,15 +14,18 @@ class CronController {
   }
 
   public function tick() {
-    die;
     $posts_array = $this->sitemap->get_all_posts();
     foreach($posts_array as $post) {
       $slug = $this->return_slug($post);
       $post_object = get_page_by_path($slug, 'OBJECT', 'post');
-      if (!$post_object->catfish_importer_imported) {
+      if (!$post_object) {
         $check = Sync::importUrl($post);
         if ($check->success) {
           $this->notify->post_import_complete($check->post->id);
+          print_r($check);
+          exit;
+        } else {
+          print_r($check);exit;
         }
       }
     }

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -1,39 +1,22 @@
 <?php
 namespace AgreableCatfishImporterPlugin\Controllers;
 
-
+use AgreableCatfishImporterPlugin\Services\Notification;
+use AgreableCatfishImporterPlugin\Services\SitemapParser;
 
 class CronController {
+
   function __construct() {
-  $slack_webhook_url = 'https://hooks.slack.com/services/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';
-    $settings = array(
-      'username' => 'Catfish Importer'
-    );
-    $this->client = $client = new \Maknz\Slack\Client($slack_webhook_url, $settings);
+    $this->notify = new Notification;
+    $this->sitemap = new SitemapParser;
   }
 
-
   public function tick() {
-    $this->test_cron();
+    echo "<pre>";
+    print_r($this->sitemap->get_all_posts());
   }
 
   public function test_cron() {
-    $current_time = date(DATE_RFC2822);
-    $this->client->attach([
-      'fallback' =>  'Imported POST NAME from SITE',
-      'color' => '#4CD964',
-      'fields' => [
-        [
-          'title' => 'Site',
-          'value' => 'Shortlist Pages',
-          'short' => true
-        ],
-        [
-          'title' => 'Post Name',
-          'value' => 'Example Post Name',
-          'short' => true
-        ]
-      ]
-    ])->send("New cron initiated message at $current_time");
+    $this->notify->post_import_complete();
   }
 }

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -14,7 +14,7 @@ class CronController {
   }
 
   public function test() {
-    return $this->notify->error('Something went wrong');
+    return $this->notify->error('Import failed in the EXAMPLE post');
   }
 
   public function tick() {
@@ -26,9 +26,8 @@ class CronController {
         try {
           $check = Sync::importUrl($post);
         } catch (Exception $e) {
-          print_r($e->getMessage());
-          //print_r("---\r\n");
-          die;
+          $error_message = $e->getMessage();
+          return $this->notify->error($error_message);
         }
         if ($check->success) {
           $this->notify->post_import_complete($check->post->id);

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -21,6 +21,7 @@ class CronController {
     $posts_array = $this->sitemap->get_all_posts_in_order();
     foreach($posts_array as $post) {
       $slug = $this->return_slug($post);
+      $slug = sanitize_title($slug);
       $post_object = get_page_by_path($slug, 'OBJECT', 'post');
       if (!$post_object) {
         try {

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -1,0 +1,39 @@
+<?php
+namespace AgreableCatfishImporterPlugin\Controllers;
+
+
+
+class CronController {
+  function __construct() {
+  $slack_webhook_url = 'https://hooks.slack.com/services/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';
+    $settings = array(
+      'username' => 'Catfish Importer'
+    );
+    $this->client = $client = new \Maknz\Slack\Client($slack_webhook_url, $settings);
+  }
+
+
+  public function tick() {
+    $this->test_cron();
+  }
+
+  public function test_cron() {
+    $current_time = date(DATE_RFC2822);
+    $this->client->attach([
+      'fallback' =>  'Imported POST NAME from SITE',
+      'color' => '#4CD964',
+      'fields' => [
+        [
+          'title' => 'Site',
+          'value' => 'Shortlist Pages',
+          'short' => true
+        ],
+        [
+          'title' => 'Post Name',
+          'value' => 'Example Post Name',
+          'short' => true
+        ]
+      ]
+    ])->send("New cron initiated message at $current_time");
+  }
+}

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -14,11 +14,11 @@ class CronController {
   }
 
   public function test() {
-    return $this->notify->error('Import failed in the EXAMPLE post');
+    return $this->sitemap->get_all_posts_in_order();
   }
 
   public function tick() {
-    $posts_array = $this->sitemap->get_all_posts();
+    $posts_array = $this->sitemap->get_all_posts_in_order();
     foreach($posts_array as $post) {
       $slug = $this->return_slug($post);
       $post_object = get_page_by_path($slug, 'OBJECT', 'post');
@@ -33,7 +33,7 @@ class CronController {
           $this->notify->post_import_complete($check->post->id);
           print_r($check);
         } else {
-          print_r($check);exit;
+          print_r($check);
         }
       }
     }

--- a/app/Controllers/CronController.php
+++ b/app/Controllers/CronController.php
@@ -13,17 +13,26 @@ class CronController {
     $this->sitemap = new SitemapParser;
   }
 
+  public function test() {
+    return $this->notify->error('Something went wrong');
+  }
+
   public function tick() {
     $posts_array = $this->sitemap->get_all_posts();
     foreach($posts_array as $post) {
       $slug = $this->return_slug($post);
       $post_object = get_page_by_path($slug, 'OBJECT', 'post');
       if (!$post_object) {
-        $check = Sync::importUrl($post);
+        try {
+          $check = Sync::importUrl($post);
+        } catch (Exception $e) {
+          print_r($e->getMessage());
+          //print_r("---\r\n");
+          die;
+        }
         if ($check->success) {
           $this->notify->post_import_complete($check->post->id);
           print_r($check);
-          exit;
         } else {
           print_r($check);exit;
         }

--- a/app/Controllers/SlackFeedbackController.php
+++ b/app/Controllers/SlackFeedbackController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AgreableCatfishImporterPlugin\Controllers;
+
+use AgreableCatfishImporterPlugin\Services\Notification;
+use AgreableCatfishImporterPlugin\Services\Post;
+
+class SlackFeedbackController {
+
+  function __construct() {
+    $this->notifiy = new Notification;
+  }
+
+  public function retry() {
+    // Have to use a query string, as wordpress tries to
+    // parse the URL if it's in a /retry/{id} param
+    $catfish_url = $_GET['url'];
+    $check = Post::getPostFromUrl($catfish_url);
+    if ($check) {
+      $permalink = get_permalink($check->id);
+      header("Location: $permalink");
+    } else {
+      echo "<h1>Failed to import</h1>";
+      echo "<p>Consider trashing</p>";
+    }
+  }
+
+  public function ignore() {
+    $catfish_url = $_GET['url'];
+  }
+
+
+}
+

--- a/app/Services/Notification.php
+++ b/app/Services/Notification.php
@@ -1,0 +1,41 @@
+<?php
+namespace AgreableCatfishImporterPlugin\Services;
+
+use \TimberPost;
+
+class Notification {
+  function __construct() {
+  date_default_timezone_set('GMT');
+  $slack_webhook_url = 'https://hooks.slack.com/services/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';
+    $settings = array(
+      'username' => 'Catfish Importer'
+    );
+    $this->site_name = get_bloginfo('name');
+    $this->client = $client = new \Maknz\Slack\Client($slack_webhook_url, $settings);
+  }
+
+  public function post_import_complete($post_id = false) {
+    if ($post_id) {
+      $post = new TimberPost($post_id);
+    }
+
+    $current_time = gmdate(DATE_RFC2822);
+    $this->client->attach([
+      'fallback' =>  "Imported POST NAME from $this->site_name",
+      'color' => '#4CD964',
+      'text' => 'http://pages-local.stylist.co.uk/example-guid',
+      'fields' => [
+        [
+          'title' => 'Site',
+          'value' => $this->site_name,
+          'short' => true
+        ],
+        [
+          'title' => 'Post Name',
+          'value' => 'Example Post Name',
+          'short' => true
+        ]
+      ]
+    ])->send("_New post imported at ".$current_time."_ ".date_default_timezone_get());
+  }
+}

--- a/app/Services/Notification.php
+++ b/app/Services/Notification.php
@@ -15,15 +15,12 @@ class Notification {
   }
 
   public function post_import_complete($post_id = false) {
-    if ($post_id) {
-      $post = new TimberPost($post_id);
-    }
 
+    $post = new TimberPost($post_id);
     $current_time = gmdate(DATE_RFC2822);
     $this->client->attach([
-      'fallback' =>  "Imported POST NAME from $this->site_name",
+      'fallback' =>  "Imported $post->post_title from $this->site_name",
       'color' => '#4CD964',
-      'text' => 'http://pages-local.stylist.co.uk/example-guid',
       'fields' => [
         [
           'title' => 'Site',
@@ -32,9 +29,18 @@ class Notification {
         ],
         [
           'title' => 'Post Name',
-          'value' => 'Example Post Name',
+          'value' => $post->post_title,
           'short' => true
+        ],
+        [
+          'title' => 'Imported from:',
+          'value' => $post->catfish_importer_url
+        ],
+        [
+          'title' => 'Imported to:',
+          'value' => $post->guid
         ]
+
       ]
     ])->send("_New post imported at ".$current_time."_ ".date_default_timezone_get());
   }

--- a/app/Services/Notification.php
+++ b/app/Services/Notification.php
@@ -19,7 +19,7 @@ class Notification {
       'fallback' =>  $message,
       'color' => '#FF3B30',
       'text' => $message
-    ])->send('Something went wrong');
+    ])->send('Something went wrong:');
   }
 
   public function post_import_complete($post_id = false) {

--- a/app/Services/Notification.php
+++ b/app/Services/Notification.php
@@ -6,16 +6,18 @@ use \TimberPost;
 class Notification {
   function __construct() {
   date_default_timezone_set('GMT');
-  $slack_webhook_url = 'https://hooks.slack.com/services/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';
+  $slack_webhook_url = "https://hooks.slack.com/services/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";
+  $slack_webhook_error_url = "https://hooks.slack.com/services/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";
     $settings = array(
       'username' => 'Catfish Importer'
     );
     $this->site_name = get_bloginfo('name');
     $this->client = $client = new \Maknz\Slack\Client($slack_webhook_url, $settings);
+    $this->errorClient = $client = new \Maknz\Slack\Client($slack_webhook_error_url, $settings);
   }
 
   public function error($message) {
-    $this->client->attach([
+    $this->errorClient->attach([
       'fallback' =>  $message,
       'color' => '#FF3B30',
       'text' => $message
@@ -29,7 +31,7 @@ class Notification {
     $this->client->attach([
       'fallback' =>  "Imported $post->post_title from $this->site_name",
       'color' => '#4CD964',
-      'text' => "*".$post->post_title."*",
+      'text' => $post->post_title,
       'fields' => [
         [
           'title' => 'Site',

--- a/app/Services/Notification.php
+++ b/app/Services/Notification.php
@@ -14,6 +14,14 @@ class Notification {
     $this->client = $client = new \Maknz\Slack\Client($slack_webhook_url, $settings);
   }
 
+  public function error($message) {
+    $this->client->attach([
+      'fallback' =>  $message,
+      'color' => '#FF3B30',
+      'text' => $message
+    ])->send('Something went wrong');
+  }
+
   public function post_import_complete($post_id = false) {
 
     $post = new TimberPost($post_id);
@@ -21,6 +29,7 @@ class Notification {
     $this->client->attach([
       'fallback' =>  "Imported $post->post_title from $this->site_name",
       'color' => '#4CD964',
+      'text' => "*".$post->post_title."*",
       'fields' => [
         [
           'title' => 'Site',
@@ -28,8 +37,8 @@ class Notification {
           'short' => true
         ],
         [
-          'title' => 'Post Name',
-          'value' => $post->post_title,
+          'title' => 'Type',
+          'value' => $post->article_type,
           'short' => true
         ],
         [
@@ -38,7 +47,7 @@ class Notification {
         ],
         [
           'title' => 'Imported to:',
-          'value' => $post->guid
+          'value' => get_permalink($post_id)
         ]
 
       ]

--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -66,16 +66,16 @@ class Post {
     $meshPost->set('short_headline', $postObject->shortHeadline, true);
     $meshPost->set('sell', $sell, true);
 
-    $meshPost->set('catfish-importer_imported', true, true);
+    $meshPost->set('catfish_importer_imported', true, true);
 
     // If automated testing, set some metadata
     if (isset($_SERVER['is-automated-testing'])) {
       $meshPost->set('automated_testing', true, true);
     }
 
-    $meshPost->set('catfish-importer_url', $postUrl, true);
-    $meshPost->set('catfish-importer_imported', true, true);
-    $meshPost->set('catfish-importer_date-updated', time(), true);
+    $meshPost->set('catfish_importer_url', $postUrl, true);
+    $meshPost->set('catfish_importer_imported', true, true);
+    $meshPost->set('catfish_importer_date_updated', time(), true);
 
     if (!$post = new TimberPost($meshPost->id)) {
       throw new \Exception('Unexpected exception where Mesh did not create/fetch a post');

--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -5,25 +5,42 @@ use \stdClass;
 use \WP_Post;
 use \TimberPost;
 use Sunra\PhpSimple\HtmlDomParser;
+use AgreableCatfishImporterPlugin\Services\Notification;
 
 use AgreableCatfishImporterPlugin\Services\User;
 use AgreableCatfishImporterPlugin\Services\Category;
 
+use Exception;
+
 class Post {
+
+  public static function notifyError($message) {
+    $notifier = new Notification;
+    $notifier->error($message);
+  }
+
   public static function getPostFromUrl($postUrl) {
+    $fail = false;
     $postJsonUrl = $postUrl . '.json';
     try {
       $postString = file_get_contents($postJsonUrl);
     } catch (Exception $e) {
-      throw new \Exception('Unable to retrieve JSON from URL ' . $postJsonUrl);
+      self::notifyError('Unable to retrieve JSON from URL ' . $postJsonUrl);
+      return false;
     }
 
     if (!$object = json_decode($postString)) {
-      throw new \Exception('Unable to retrieve JSON from URL ' . $postJsonUrl);
+      self::notifyError('Unable to retrieve JSON from URL ' . $postJsonUrl);
+      $fail = true;
     }
 
     if (!isset($object->article)) {
-      throw new \Exception('"Article" property does not exist in JSON');
+      self::notifyError('"Article" property does not exist in JSON, might be a full page embed or microsite');
+      $fail = true;
+    }
+
+    if ($fail) {
+      return false;
     }
 
     $postObject = $object->article;
@@ -78,7 +95,7 @@ class Post {
     $meshPost->set('catfish_importer_date_updated', time(), true);
 
     if (!$post = new TimberPost($meshPost->id)) {
-      throw new \Exception('Unexpected exception where Mesh did not create/fetch a post');
+      self::notifyError('Unexpected exception where Mesh did not create/fetch a post');
     }
 
     self::setHeroImages($post, $postDom);
@@ -120,9 +137,14 @@ class Post {
 
     }
 
-    update_post_meta($post->id, 'hero_images', $heroImageIds);
-    update_post_meta($post->id, '_hero_images', 'article_basic_hero_images');
-    set_post_thumbnail($post->id, $heroImageIds[0]);
+    if (array_key_exists(0, $heroImageIds)) {
+      update_post_meta($post->id, 'hero_images', $heroImageIds);
+      update_post_meta($post->id, '_hero_images', 'article_basic_hero_images');
+      set_post_thumbnail($post->id, $heroImageIds[0]);
+    } else {
+      $message = "$post->title has no hero images";
+      self::notifyError($message);
+    }
   }
 
   public static function getCategory(TimberPost $post) {

--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -48,6 +48,9 @@ class Post {
     $postReformatted = new stdClass();
 
     $meshPost = new \Mesh\Post($postObject->slug);
+    $meshPost->set('catfish_importer_url', $postUrl, true);
+    $meshPost->set('catfish_importer_imported', true, true);
+    $meshPost->set('catfish_importer_date_updated', time(), true);
     $meshPost->set('post_title', $postObject->headline);
 
     // Set post published date
@@ -90,9 +93,6 @@ class Post {
       $meshPost->set('automated_testing', true, true);
     }
 
-    $meshPost->set('catfish_importer_url', $postUrl, true);
-    $meshPost->set('catfish_importer_imported', true, true);
-    $meshPost->set('catfish_importer_date_updated', time(), true);
 
     if (!$post = new TimberPost($meshPost->id)) {
       self::notifyError('Unexpected exception where Mesh did not create/fetch a post');

--- a/app/Services/SitemapParser.php
+++ b/app/Services/SitemapParser.php
@@ -50,6 +50,35 @@ class SitemapParser {
     return $posts;
   }
 
+  public function merge_sections_in_order($sections) {
+    $counts = array_map('count', $sections);
+    $key = array_flip($counts)[max($counts)];
+    $largest_section = $sections[$key];
+    echo $key."</br><pre>";
+    print_r($largest_section);die;
+  }
+
+  public function get_longest_section_length($sections) {
+    $counts = array_map('count', $sections);
+    $key = array_flip($counts)[max($counts)];
+    $largest_section = $sections[$key];
+    return count($largest_section);
+  }
+
+  public function get_all_posts_in_order() {
+    $posts = array();
+    $sorted_sections = $this->get_all_posts_sorted();
+    $length = $this->get_longest_section_length($sorted_sections);
+    for ($i = 0; $i <= $length; $i++) {
+      foreach($sorted_sections as $section) {
+        if (array_key_exists($i, $section)) {
+          array_push($posts, $section[$i]);
+        }
+      }
+    }
+    return $posts;
+  }
+
   public function get_all_posts() {
     $posts = array();
     $sections = $this->get_sections();

--- a/app/Services/SitemapParser.php
+++ b/app/Services/SitemapParser.php
@@ -1,0 +1,65 @@
+<?php
+namespace AgreableCatfishImporterPlugin\Services;
+
+use Sabre;
+use Sabre\Xml\Reader;
+
+class SitemapParser {
+
+  function __construct() {
+    $this->sitemap_url = get_field('catfish_website_url', 'option')."sitemap-index.xml";
+    $this->sitemap_xml = file_get_contents($this->sitemap_url);
+    $this->service = new \Sabre\Xml\Service();
+    $this->do_mapping();
+  }
+
+  private function do_mapping() {
+    $this->service->elementMap = [
+      '{http://www.sitemaps.org/schemas/sitemap/0.9}sitemapindex' => function(Reader $reader) {
+        return Sabre\Xml\Deserializer\repeatingElements($reader, '{http://www.sitemaps.org/schemas/sitemap/0.9}sitemap');
+      },
+      '{http://www.sitemaps.org/schemas/sitemap/0.9}urlset' => function(Reader $reader) {
+        return Sabre\Xml\Deserializer\repeatingElements($reader, '{http://www.sitemaps.org/schemas/sitemap/0.9}url');
+      }
+    ];
+  }
+
+  public function filter_node_value(&$node) {
+    return $node = $node[0]['value'];
+  }
+
+  public function get_section_posts($url) {
+    $section_xml = file_get_contents($url);
+    $loc_nodes = $this->service->parse($section_xml);
+    array_walk($loc_nodes, array($this, 'filter_node_value'));
+    return $loc_nodes;
+  }
+
+  public function get_sections() {
+    $loc_nodes = $this->service->parse($this->sitemap_xml);
+    array_walk($loc_nodes, array($this, 'filter_node_value'));
+    return $loc_nodes;
+  }
+
+  public function get_all_posts_sorted() {
+    $posts = array();
+    $sections = $this->get_sections();
+    foreach($sections as  $section) {
+      $posts[$section] = $this->get_section_posts($section);
+    }
+    return $posts;
+  }
+
+  public function get_all_posts() {
+    $posts = array();
+    $sections = $this->get_sections();
+    foreach($sections as  $section) {
+      $section_posts = $this->get_section_posts($section);
+      foreach($section_posts as $post) {
+        array_push($posts, $post);
+      }
+    }
+    return $posts;
+  }
+
+}

--- a/app/custom-fields/acf.php
+++ b/app/custom-fields/acf.php
@@ -4,8 +4,8 @@ if( function_exists('acf_add_local_field_group') ):
 
 $field['group'] = 'article_basic_group';
 $field['parent'] = 'article_basic_group';
-$field['key'] = 'article_catfish-importer_imported';
-$field['name'] = 'catfish-importer_imported';
+$field['key'] = 'article_catfish_importer_imported';
+$field['name'] = 'catfish_importer_imported';
 $field['label'] = 'Catfish imported';
 $field['type'] = 'true_false';
 $field['default_value'] = 0;
@@ -15,13 +15,13 @@ $field['instructions'] = 'Is this post imported from Catfish?';
 $field['message'] = '';
 
 acf_add_local_field_group(array (
-  'key' => 'article_catfish-importer_group',
+  'key' => 'article_catfish_importer_group',
   'title' => 'Catfish Importer',
   'fields' => array (
     array (
-      'key' => 'article_catfish-importer_imported',
+      'key' => 'article_catfish_importer_imported',
       'label' => 'Imported',
-      'name' => 'catfish-importer_imported',
+      'name' => 'catfish_importer_imported',
       'type' => 'true_false',
       'instructions' => 'Is this post imported from Catfish?',
       'required' => 0,
@@ -35,9 +35,9 @@ acf_add_local_field_group(array (
       'default_value' => 0,
     ),
     array (
-      'key' => 'article_catfish-importer_date-updated',
+      'key' => 'article_catfish_importer_date_updated',
       'label' => 'Updated',
-      'name' => 'catfish-importer_date-updated',
+      'name' => 'catfish_importer_date_updated',
       'type' => 'date_time_picker',
       'instructions' => 'When did the importer update this post?',
       'required' => 0,
@@ -56,9 +56,9 @@ acf_add_local_field_group(array (
       'get_as_timestamp' => 'true',
     ),
     array (
-      'key' => 'article_catfish-importer_url',
+      'key' => 'article_catfish_importer_url',
       'label' => 'URL',
-      'name' => 'catfish-importer_url',
+      'name' => 'catfish_importer_url',
       'type' => 'url',
       'instructions' => 'The URL from imported from',
       'required' => 0,

--- a/app/custom-fields/acf.php
+++ b/app/custom-fields/acf.php
@@ -56,7 +56,7 @@ acf_add_local_field_group(array (
       'get_as_timestamp' => 'true',
     ),
     array (
-      'key' => 'article_catfish_importer_url',
+      'key' => 'article_catfish_imported_url',
       'label' => 'URL',
       'name' => 'catfish_importer_url',
       'type' => 'url',

--- a/app/custom-fields/acf.php
+++ b/app/custom-fields/acf.php
@@ -82,7 +82,7 @@ acf_add_local_field_group(array (
       ),
     ),
   ),
-  'menu_order' => 0,
+  'menu_order' => 100,
   'position' => 'normal',
   'style' => 'default',
   'label_placement' => 'top',

--- a/app/hooks.php
+++ b/app/hooks.php
@@ -12,9 +12,10 @@ class ImporterHooks {
 
   public function add_retry_button($actions, $post) {
     $post = new TimberPost($post);
-    $actions['re_import'] = $this->get_html($post);
+    if ($post->catfish_importer_url) {
+      $actions['re_import'] = $this->get_html($post);
+    }
     return $actions;
-
   }
 
   public function get_html($post) {

--- a/app/hooks.php
+++ b/app/hooks.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AgreableCatfishImporterPlugin\Hooks;
+
+use add_filter;
+use TimberPost;
+
+class ImporterHooks {
+  function __construct() {
+    add_filter('post_row_actions', array($this, 'add_retry_button'), 10, 2);
+  }
+
+  public function add_retry_button($actions, $post) {
+    $post = new TimberPost($post);
+    $actions['re_import'] = $this->get_html($post);
+    return $actions;
+
+  }
+
+  public function get_html($post) {
+    $link = $this->get_link($post);
+    return "<a title='Re-import from Catfish' class='reimport' href='$link'>Reimport</a>";
+  }
+
+  public function get_link($post) {
+    $catfish_url = $post->catfish_importer_url;
+    return get_bloginfo('url')."/catfish-import/retry?url=$catfish_url";
+  }
+
+}
+
+new ImporterHooks;
+

--- a/app/routes.php
+++ b/app/routes.php
@@ -3,13 +3,14 @@
 /** @var \Herbert\Framework\Router $router */
 
 $router->get([
+  'as'   => 'testNotification',
+  'uri'  => '/catfish-import-test',
+  'uses' => __NAMESPACE__ . '\Controllers\CronController@test'
+]);
+
+$router->get([
   'as'   => 'cronNotification',
   'uri'  => '/catfish-import',
   'uses' => __NAMESPACE__ . '\Controllers\CronController@tick'
 ]);
 
-$router->get([
-  'as'   => 'cronNotification',
-  'uri'  => '/catfish-import-test',
-  'uses' => __NAMESPACE__ . '\Controllers\CronController@test'
-]);

--- a/app/routes.php
+++ b/app/routes.php
@@ -3,14 +3,26 @@
 /** @var \Herbert\Framework\Router $router */
 
 $router->get([
+  'as'   => 'retryPost',
+  'uri'  => '/catfish-import/retry',
+  'uses' => __NAMESPACE__ . '\Controllers\SlackFeedbackController@retry'
+]);
+
+$router->get([
+  'as'   => 'ignorePost',
+  'uri'  => '/catfish-import/ignore',
+  'uses' => __NAMESPACE__ . '\Controllers\SlackFeedbackController@ignore'
+]);
+
+$router->get([
   'as'   => 'testNotification',
-  'uri'  => '/test-notification',
+  'uri'  => '/catfish-import/test-notification',
   'uses' => __NAMESPACE__ . '\Controllers\CronController@test'
 ]);
 
 $router->get([
   'as'   => 'cronNotification',
-  'uri'  => '/catfish-import',
+  'uri'  => '/catfish-import/run',
   'uses' => __NAMESPACE__ . '\Controllers\CronController@tick'
 ]);
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -1,3 +1,9 @@
 <?php namespace AgreableCatfishImporterPlugin;
 
 /** @var \Herbert\Framework\Router $router */
+
+$router->get([
+  'as'   => 'cronNotification',
+  'uri'  => '/catfish-import',
+  'uses' => __NAMESPACE__ . '\Controllers\CronController@tick'
+]);

--- a/app/routes.php
+++ b/app/routes.php
@@ -4,7 +4,7 @@
 
 $router->get([
   'as'   => 'testNotification',
-  'uri'  => '/catfish-import-test',
+  'uri'  => '/test-notification',
   'uses' => __NAMESPACE__ . '\Controllers\CronController@test'
 ]);
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -7,3 +7,9 @@ $router->get([
   'uri'  => '/catfish-import',
   'uses' => __NAMESPACE__ . '\Controllers\CronController@tick'
 ]);
+
+$router->get([
+  'as'   => 'cronNotification',
+  'uri'  => '/catfish-import-test',
+  'uses' => __NAMESPACE__ . '\Controllers\CronController@test'
+]);

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "behat/behat": "~2.5",
     "phpunit/phpunit": "5.0.*",
     "sunra/php-simple-html-dom-parser" : "~1.5",
-    "maknz/slack": "^1.7"
+    "maknz/slack": "^1.7",
+    "sabre/xml": "^1.4"
   },
   "config": {
     "preferred-install": "dist"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "jarednova/mesh": "*",
     "behat/behat": "~2.5",
     "phpunit/phpunit": "5.0.*",
-    "sunra/php-simple-html-dom-parser" : "~1.5"
+    "sunra/php-simple-html-dom-parser" : "~1.5",
+    "maknz/slack": "^1.7"
   },
   "config": {
     "preferred-install": "dist"

--- a/herbert.config.php
+++ b/herbert.config.php
@@ -12,7 +12,8 @@ return [
      * Auto-load all required files.
      */
     'requires' => [
-        __DIR__ . '/app/custom-fields/acf.php'
+      __DIR__ . '/app/custom-fields/acf.php',
+      __DIR__ . '/app/hooks.php'
     ],
 
     /**

--- a/resources/views/admin/index.twig
+++ b/resources/views/admin/index.twig
@@ -15,7 +15,7 @@
       <td><a href="/wp/wp-admin/post.php?post={{ post.id }}&action=edit">{{ post.post_title }}</a></td>
       <td>{{ post.terms('category')[0] }}</td>
       <td>{{ post.post_date }}</td>
-      <td>{{ post.get_field('catfish-importer_date-updated') | date }}</td>
+      <td>{{ post.get_field('catfish_importer_date_updated') | date }}</td>
       <td><a href="{{post.get_author.get_link}}">{{ post.get_author.name }}</a></td>
     </tr>
   {% endfor %}

--- a/tests/features/bootstrap/PostContext.php
+++ b/tests/features/bootstrap/PostContext.php
@@ -132,8 +132,8 @@ class PostContext extends BehatContext {
    * @Given /^the post has import metadata$/
    */
   public function thePostHasImportMetadata() {
-    Assert::assertEquals(true, self::$post->get_field('catfish-importer_imported'));
-    Assert::assertNotNull(self::$post->get_field('catfish-importer_date-updated'));
+    Assert::assertEquals(true, self::$post->get_field('catfish_importer_imported'));
+    Assert::assertNotNull(self::$post->get_field('catfish_importer_date_updated'));
   }
 
   /**


### PR DESCRIPTION
A load of changes so the importer is ready for "auto importing". 

Key features:
 - Reports to slack when there's a successful import
 - Reports to slack when there's a failed import
 - More detailed SiteMap parsing
 - Various bug fixes
 - I've left the Embed's stuff out of here for the moment, because I came across a load of bugs recently, worth going into  another PR anywaay 
- I've left out the slack ignore button concept, as I wanted to do it properly with the getherbert model concept. (There are some articles in Catfish that will never import - legacy/embeds - and we want a button to say "Ignore this forever and stop sending error notifications"

@ecoad @KimberleyCook @iamdeaneyelid 