### PR TITLE
Speedtest post import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Agreable Catfish Importer Plugin
 ===============
 
-TBC
+For importing Catfish content in to Croissant

--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -19,8 +19,14 @@ class Post {
     $notifier->error($message);
   }
 
-  public static function getPostFromUrl($postUrl) {
-    $fail = false;
+  public static function getPostFromUrl($postUrl, $speedtest = false) {
+
+    // Start speedtest timer
+    if($speedtest) {
+      $speedtestData = array();
+      $speedtestData['startTime'] = microtime(true);
+    }
+
     $postJsonUrl = $postUrl . '.json';
     try {
       $postString = file_get_contents($postJsonUrl);
@@ -124,6 +130,13 @@ class Post {
 
     // Envoke any actions hooked to the 'catfish_importer_post' tag
     do_action('catfish_importer_post', $post->ID);
+
+    // End speedtest timer
+    if($speedtest) {
+      $speedtestData['endTime'] = microtime(true);
+      $speedtestData['time'] = $speedtestData['endTime'] - $speedtestData['startTime'] ;
+      $post->speedtest = $speedtestData;
+    }
 
     return $post;
   }

--- a/app/Services/Sitemap.php
+++ b/app/Services/Sitemap.php
@@ -27,6 +27,6 @@ class Sitemap {
       }
       return $urls;
     }
-    return null;
+    return [];
   }
 }

--- a/app/Services/Sitemap.php
+++ b/app/Services/Sitemap.php
@@ -12,6 +12,12 @@ class Sitemap {
   }
 
   protected static function getUrlsFromSitemap($sitemapLocation) {
+    // Catch if sub sitemap doesn't exist - Clock strangeness
+    $siteMapHeaders = get_headers($sitemapLocation, 1);
+    if ( strstr($siteMapHeaders[0], '200') == false ) {
+      return [];
+    }
+
     $sitemap = HtmlDomParser::file_get_html($sitemapLocation);
     $urls = [];
     // Only process if object is returned

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -159,7 +159,6 @@ class Sync {
 
     }
 
-    // die(var_dump($speedAverage, $speedTypeAverage));
     $speedTest->data['speedData'] = $speedAverage;
     $speedTest->data['speedAverageData'] = $speedTypeAverage;
 

--- a/app/Services/Widget.php
+++ b/app/Services/Widget.php
@@ -166,7 +166,8 @@ class Widget {
 
     foreach($postDom->find('.article__content .widget__wrapper') as $widgetWrapper) {
 
-      if (isset($widgetWrapper->find('.widget')[0])) {
+      // Catch html widgets being passed boolean with is_object($widgetWrapper->find('.widget')[0])
+      if (isset($widgetWrapper->find('.widget')[0]) && is_object($widgetWrapper->find('.widget')[0])) {
         $widget = $widgetWrapper->find('.widget')[0];
 
         // Get class name
@@ -181,6 +182,7 @@ class Widget {
 
         switch ($widgetName) {
           case 'html':
+            // This
             $widgetData = Html::getFromWidgetDom($widget);
             break;
           case 'inline-image':

--- a/app/Services/Widgets/Html.php
+++ b/app/Services/Widgets/Html.php
@@ -102,7 +102,7 @@ class Html {
           $carry->type = $item->type;
           $carry->html .= $item->html;
 
-        // Collection doesn't error so catch any Exceptions hee
+        // Collection doesn't error so catch any Exceptions here
         } catch (\Exception $e) {
           print_r($e);
         }

--- a/app/Services/Widgets/Paragraph.php
+++ b/app/Services/Widgets/Paragraph.php
@@ -5,6 +5,13 @@ use stdClass;
 
 class Paragraph {
   public static function getFromWidgetDom($widgetDom) {
+    // TODO: Trying to get property of non-object
+    // Catch bug on long tail post
+    if(!is_object($widgetDom)) {
+      // Dom object not passed
+      die(var_dump('Widget DOM not passed as an object.', $widgetDom, debug_backtrace()));
+      return null;
+    }
     $widgetData = new stdClass();
     $widgetData->type = 'paragraph';
     $widgetDom = self::filterBadTags($widgetDom);
@@ -14,6 +21,12 @@ class Paragraph {
 
   public static function filterBadTags($html) {
     $badTags = 'span, center';
+    // TODO: Trying to get property of non-object
+    // catch $html is boolean and work out why
+    if( !is_object($html) ) {
+      die(var_dump('$html not passed as a DOM object object.', $widgetDom));
+      return null;
+    }
     if (count($html->find($badTags))) {
       foreach($html->find($badTags) as $index=>$element) {
         $html->find($badTags, $index)->outertext = $element->innertext;

--- a/app/api.php
+++ b/app/api.php
@@ -29,6 +29,12 @@ add_action('wp_ajax_catfishimporter_get_status', function() {
   catfishimporter_api_response($response);
 });
 
+// Speedtest API endpoint
+add_action('wp_ajax_catfishimporter_speedtest', function() {
+  $response = Sync::runSpeedtest();
+  catfishimporter_api_response($response);
+});
+
 add_action('wp_ajax_catfishimporter_get_category_status', function() {
   if (!isset($_GET['sitemapUrl']) || !$_GET['sitemapUrl']) {
     throw new Exception('sitemapUrl is missing from query');

--- a/resources/assets/javascripts/admin.js
+++ b/resources/assets/javascripts/admin.js
@@ -12,6 +12,7 @@ jQuery(function() {
   var $syncUrlButton = $('input[name=sync-url]')
   var $syncUrl = $('input[name=url]')
   var $status = $('.import-status')
+  var $speedtest = $('.speedtest-status')
   var ajaxUrl = $('.ajax-url').html()
 
   $syncCategoryButton.click(onSyncCategoryClick)
@@ -19,6 +20,7 @@ jQuery(function() {
 
   listSections()
   getCurrentStatus()
+  runSpeedtest()
 
   function listSections() {
     $.getJSON(ajaxUrl + '?action=catfishimporter_list_categories', function onListSections(response) {
@@ -110,7 +112,7 @@ jQuery(function() {
     $.get(
       ajaxUrl + '?action=catfishimporter_get_status',
       function onResponse(response) {
-        console.log(response)
+        console.log(response);
         $status.html('Current status: imported ' +
           response.importedCount + ' out of ' + response.total +
           ' (' + Math.round((response.importedCount/response.total)*100) + '%)\r\n')
@@ -122,5 +124,32 @@ jQuery(function() {
     })
   }
 
+  /**
+   * Run a speedtest on the importer and show results
+   */
+  function runSpeedtest() {
+    $speedtest.html('Running speedtest, this may take some time&hellip;')
+    $.get(
+      ajaxUrl + '?action=catfishimporter_speedtest',
+      function onResponse(response) {
+        // Show the results/averages
+        try {
+          jQuery.parseJSON(response);
+          console.log('Speedtest Successful');
+          console.log(response);
+          $speedtest.html('Speedtest tested ' +
+            response.total + ' article imports with an average load time of ' + response.averageLoad +
+            '. Based on this average the estimated time to import all posts is ' + response.estimatedImportTime/60/60 + ' hours. \r\n' )
+        } catch(error) {
+          // Catch error output
+          $speedtest.html('Error running speedtest&hellip;')
+          console.log(error)
+        }
+      }
+    ).fail(function onSyncError(error) {
+      $speedtest.html('Error running speedtest&hellip;')
+      console.log(error)
+    })
+  }
 
 })

--- a/resources/views/admin/sync.twig
+++ b/resources/views/admin/sync.twig
@@ -35,3 +35,6 @@
 
 <h2>Status</h2>
 <pre class='import-status'>Loading current status: &hellip;</pre>
+
+<h2>Speedtest</h2>
+<pre class='speedtest-status'>Loading current status: &hellip;</pre>


### PR DESCRIPTION
Creates a speedtest flag for the import which times how long each execution of the importer takes and passes it back up the chain. Also created an interface in the Admin panel to show the response.

Separately surfaced a few bugs in importing certain long tail post to investigate in detail in follow up work.