### PR TITLE
Importer Bug: Worker running actions multiple times and Bug Fixes

### DIFF
--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -22,16 +22,30 @@ class Post {
    */
   public static function getPostFromUrl($postUrl, $onExistAction = 'skip', $cli = false, $log_identifier) {
     $fail = false;
-    $postJsonUrl = $postUrl . '.json';
+    $originalJsonUrl = $postUrl . '.json';
+
+    // Handle special characters in post import urls like:
+    $urlToEscape = parse_url($originalJsonUrl);
+
+    // Create a url encoded path
+    $escapedUrlPath = explode('/', $urlToEscape['path']);
+    foreach ($escapedUrlPath as &$url_element) {
+      $url_element = rawurlencode($url_element);
+    }
+    $escapedUrlPath = implode('/', $escapedUrlPath);
+
+    // Find and replace the old version of the path with the next escaped version
+    $postJsonUrl = str_replace($urlToEscape['path'], $escapedUrlPath, $originalJsonUrl);
+
     try {
       $postString = file_get_contents($postJsonUrl);
     } catch (Exception $e) {
       // To be caught in Sync.php
-      throw new Exception('Unable to retrieve JSON from URL ' . $postJsonUrl);
+      throw new Exception('Unable to reach post JSON URL ' . $postJsonUrl);
     }
 
     if (!$object = json_decode($postString)) {
-      throw new Exception('Unable to retrieve JSON from URL ' . $postJsonUrl);
+      throw new Exception('Unable to reach post JSON URL ' . $postJsonUrl);
     }
 
     if (!isset($object->article)) {

--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -24,18 +24,8 @@ class Post {
     $fail = false;
     $originalJsonUrl = $postUrl . '.json';
 
-    // Handle special characters in post import urls like:
-    $urlToEscape = parse_url($originalJsonUrl);
-
-    // Create a url encoded path
-    $escapedUrlPath = explode('/', $urlToEscape['path']);
-    foreach ($escapedUrlPath as &$url_element) {
-      $url_element = rawurlencode($url_element);
-    }
-    $escapedUrlPath = implode('/', $escapedUrlPath);
-
-    // Find and replace the old version of the path with the next escaped version
-    $postJsonUrl = str_replace($urlToEscape['path'], $escapedUrlPath, $originalJsonUrl);
+    // Escape the url path using this handy helper
+    $postJsonUrl = Sync::escapeAPIUrlPaths($originalJsonUrl);
 
     try {
       $postString = file_get_contents($postJsonUrl);

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -377,7 +377,7 @@ class Sync {
 
       // Queue item ran successfully, ping the Envoyer heartbeat URL to stay we're still alive
       file_get_contents(getenv('ENVOYER_HEARTBEAT_URL_UPDATED_POSTS_SCANNER'));
-      
+
     } catch (Exception $e) {
       // Show error to cli users
       if($cli) {

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -300,6 +300,14 @@ class Sync {
 
     $query = array(
       'post_type' => 'post',
+
+      // These two fields speed up a count only query massively by only returning the id
+      'fields' => 'ids',
+      // 'no_found_rows' => true,
+
+      // Return all posts at once.
+      'posts_per_page' => -1,
+
       'category_name' => $categorySlug,
       'meta_query' => array(
         array(

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -22,18 +22,21 @@ class Sync {
   /**
    * Queue Category / All
    */
-  public static function queueCategory($categorySitemap = 'all', $onExistAction = 'update') {
-    try {
-      // Push item into Queue
-      return Queue::push('importCategory', array('url' => $categorySitemap, 'onExistAction' => $onExistAction));
-    } catch (Exception $e) {
-      // Catch errors for easy debugging in BugSnag
-      if($cli) {
-        WP_CLI::error("Error in queueUrl adding importCategory to queue. " . $e->getMessage());
-      }
-      trigger_error("Error in queueUrl adding importCategory to queue. " . $e->getMessage(), E_USER_ERROR);
-    }
-  }
+  // NOTE this takes too long to run and is released back into the queue and duplicated
+  // for that reason all large imports should be run from the command line.
+
+  // public static function queueCategory($categorySitemap = 'all', $onExistAction = 'update') {
+  //   try {
+  //     // Push item into Queue
+  //     return Queue::push('importCategory', array('url' => $categorySitemap, 'onExistAction' => $onExistAction));
+  //   } catch (Exception $e) {
+  //     // Catch errors for easy debugging in BugSnag
+  //     if($cli) {
+  //       WP_CLI::error("Error in queueUrl adding importCategory to queue. " . $e->getMessage());
+  //     }
+  //     trigger_error("Error in queueUrl adding importCategory to queue. " . $e->getMessage(), E_USER_ERROR);
+  //   }
+  // }
 
   /**
    * Queue Single URL

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -84,6 +84,10 @@ class Sync {
       // max number of tries
 
       $worker->pop('default', getenv('AWS_SQS_CATFISH_IMPORTER_QUEUE'), 0, 3, 0);
+
+      // Queue item ran successfully, ping the Envoyer heartbeat URL to stay we're still alive
+      file_get_contents(getenv('ENVOYER_HEARTBEAT_URL_IMPORTER'));
+
     } catch (Exception $e) {
       if($cli) {
         WP_CLI::error("Error in the Worker library while actioning single queue item. Queue item may have exceeded maxTries. " . $e->getMessage());
@@ -370,6 +374,10 @@ class Sync {
       // Queue up posts from each category since the last successfull import
       // Import from all categories since...
       return self::importCategory($data, $payload, $cli);
+
+      // Queue item ran successfully, ping the Envoyer heartbeat URL to stay we're still alive
+      file_get_contents(getenv('ENVOYER_HEARTBEAT_URL_UPDATED_POSTS_SCANNER'));
+      
     } catch (Exception $e) {
       // Show error to cli users
       if($cli) {

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -262,6 +262,9 @@ class Sync {
       }
       trigger_error("Error importing post from url using Posts class. " . $e->getMessage(), E_USER_ERROR);
 
+      // TODO: Delete partial post if a post has been created...
+      // var_dump($e);
+
     }
   }
 
@@ -414,6 +417,28 @@ class Sync {
       // Return a date far in the past so we always import all content in this case.
       return strtotime('-5 years');
     }
+
+  }
+
+  /**
+   * Escape API Url Paths
+   *
+   * Handle special characters in post import urls
+   * (e.g. http://www.shortlist.com/entertainment/netflix picks.json)
+   */
+  public static function escapeAPIUrlPaths($originalJsonUrl) {
+
+    $urlToEscape = parse_url($originalJsonUrl);
+
+    // Create a url encoded path
+    $escapedUrlPath = explode('/', $urlToEscape['path']);
+    foreach ($escapedUrlPath as &$url_element) {
+      $url_element = rawurlencode($url_element);
+    }
+    $escapedUrlPath = implode('/', $escapedUrlPath);
+
+    // Find and replace the old version of the path with the next escaped version
+    return str_replace($urlToEscape['path'], $escapedUrlPath, $originalJsonUrl);
 
   }
 

--- a/app/Services/Widget.php
+++ b/app/Services/Widget.php
@@ -96,6 +96,10 @@ class Widget {
 
   protected static function setGalleryWidget($post, stdClass $postObject, $widgetNames) {
     $galleryApi = str_replace($postObject->__fullUrlPath, '/api/gallery-data' . $postObject->__fullUrlPath, $postObject->absoluteUrl);
+
+    // Escape the url path using this handy helper
+    $galleryApi = Sync::escapeAPIUrlPaths($galleryApi);
+
     if (!$galleryApiResponse = file_get_contents($galleryApi)) {
       throw new Exception('Unable to fetch gallery data from: ' . $galleryApi);
     }

--- a/app/Services/Worker.php
+++ b/app/Services/Worker.php
@@ -55,8 +55,6 @@ class Worker extends QueueWorker {
       // Pass on the slug to show in log file
       $log_identifier = (isset($response->log_identifier)) ? $response->log_identifier : '' ;
 
-      // die(var_dump($response->log_identifier,$response));
-
       if($this->cli) {
         WP_CLI::line($log_identifier.'Success: Worker action complete');
       }

--- a/app/Services/Worker.php
+++ b/app/Services/Worker.php
@@ -50,14 +50,23 @@ class Worker extends QueueWorker {
       // $data  the full json object from the queue including the function name and payload
       // $payload  the spefic payload data for this action
       // $cli  should WP_CLI console output be shown
-      Sync::$function($data, $payload, $this->cli);
+      $response = Sync::$function($data, $payload, $this->cli);
+
+      // Pass on the slug to show in log file
+      $log_identifier = (isset($response->log_identifier)) ? $response->log_identifier : '' ;
+
+      // die(var_dump($response->log_identifier,$response));
 
       if($this->cli) {
-        WP_CLI::success('Action complete');
+        WP_CLI::line($log_identifier.'Success: Worker action complete');
       }
 
       // Delete the job from the queue once
       $job->delete();
+
+      if($this->cli) {
+        WP_CLI::line($log_identifier.'Success: Task deleted from queue');
+      }
 
       return ['job' => $job, 'failed' => false];
 
@@ -66,23 +75,24 @@ class Worker extends QueueWorker {
       // Try to release the job back into the queue to try again later
       $this->handleJobException($connection, $job, $delay, $e);
 
-      // then handle the error
+      // Show the error to the cli
       if($this->cli) {
-        WP_CLI::error("Exception completing queue item within the Illuminate code. " . $e->getMessage());
+        WP_CLI::line($log_identifier.'Error: Task released back to queue');
+        WP_CLI::error($log_identifier.$e->getMessage());
       }
-      throw new Exception("Exception completing queue item within the Illuminate code. " . $e->getMessage(), 1);
+      trigger_error($log_identifier.$e->getMessage(), E_USER_ERROR);
 
+    // Repeated from above for Illuminate's error handline namespace
     } catch (Throwable $e) {
-
       // Try to release the job back into the queue to try again later
       $this->handleJobException($connection, $job, $delay, $e);
 
-      // then handle the error
+      // Show the error to the cli
       if($this->cli) {
-        WP_CLI::error("Throwable Exception completing queue item within the Illuminate code. " . $e->getMessage());
+        WP_CLI::line($log_identifier.'Error: Task released back to queue');
+        WP_CLI::error($log_identifier.$e->getMessage());
       }
-      throw new Exception("Throwable Exception completing queue item within the Illuminate code. " . $e->getMessage(), 1);
-
+      trigger_error($log_identifier.$e->getMessage(), E_USER_ERROR);
     }
   }
 

--- a/app/api.php
+++ b/app/api.php
@@ -1,5 +1,7 @@
 <?php namespace AgreableCatfishImporterPlugin;
 
+// die('API loaded');
+
 use AgreableCatfishImporterPlugin\Services\Sync;
 use \Exception;
 
@@ -37,6 +39,7 @@ add_action('wp_ajax_catfishimporter_list_categories', function() {
  * Return total imported posts
  */
 add_action('wp_ajax_catfishimporter_get_status', function() {
+  die(1);
   $response = Sync::getImportStatus();
   catfishimporter_api_response($response);
 });

--- a/app/api.php
+++ b/app/api.php
@@ -39,7 +39,6 @@ add_action('wp_ajax_catfishimporter_list_categories', function() {
  * Return total imported posts
  */
 add_action('wp_ajax_catfishimporter_get_status', function() {
-  die(1);
   $response = Sync::getImportStatus();
   catfishimporter_api_response($response);
 });

--- a/app/cli.php
+++ b/app/cli.php
@@ -4,6 +4,7 @@ use AgreableCatfishImporterPlugin\Services\Post;
 use AgreableCatfishImporterPlugin\Services\Sync;
 use AgreableCatfishImporterPlugin\Services\Queue;
 
+
 /**
  * Generate a random key for the application.
  *
@@ -26,6 +27,34 @@ function generateRandomKey() {
 
 // Register command with WP_CLI
 WP_CLI::add_command('catfish generatekey', 'generateRandomKey');
+
+/**
+ * Throws an exception that should be tracked by BugSnag
+ *
+ * ## DESCRIPTION
+ *
+ * Throws a new exeption that can be used for testing error tracking within the cli.
+ *
+ * ## OPTIONS
+ *
+ * ## EXAMPLES
+ *
+ *     # Add all a specified post
+ *     wp catfish testexception
+ *
+ */
+function testException() {
+  // Show my errors
+  ini_set('display_errors', 1);
+  ini_set('display_startup_errors', 1);
+  error_reporting(E_ERROR | E_WARNING | E_PARSE);
+
+  // Trigger an error
+  trigger_error('Bugsnag Test Exception', E_USER_ERROR);
+}
+
+// Register command with WP_CLI
+WP_CLI::add_command('catfish testexception', 'testException');
 
 /**
  * Add Items to Catfish Queue.

--- a/app/cli.php
+++ b/app/cli.php
@@ -96,7 +96,9 @@ function addToQueue(array $args) {
   if($args[0] == 'all' || strstr($args[0], '.xml')) {
     WP_CLI::line('Queueing category.');
 
-    Sync::queueCategory($args[0]); // TODO: Handle onExistAction
+    // Queue action is too long to run without being released back into the queue.
+    // Instead run all large queue adds on the command line
+    Sync::importCategory('', array('url' => $args[0], 'onExistAction' => 'update'), true);
 
     WP_CLI::success('Queued: ' . $args[0]);
   } else {

--- a/herbert.config.php
+++ b/herbert.config.php
@@ -68,7 +68,7 @@ return [
     /**
      * The API to auto-load.
      */
-    'api' => [
+    'apis' => [
         'AgreableCatfishImporterPlugin' => __DIR__ . '/app/api.php'
     ],
 

--- a/herbert.config.php
+++ b/herbert.config.php
@@ -66,10 +66,10 @@ return [
     ],
 
     /**
-     * The Cron to auto-load.
+     * The API to auto-load.
      */
-    'cron' => [
-        'AgreableCatfishImporterPlugin' => __DIR__ . '/app/cron.php'
+    'api' => [
+        'AgreableCatfishImporterPlugin' => __DIR__ . '/app/api.php'
     ],
 
     /**

--- a/resources/views/admin/sync.twig
+++ b/resources/views/admin/sync.twig
@@ -1,6 +1,9 @@
 <h1>Catfish Importer</h1>
 <div class="ajax-url" style="display: none;">{{ ajax_url }}</div>
 <h2>Sync a Category</h2>
+<p>
+  To run full site imports use the Catfish command line tools. To queue all posts for import run <pullquote>wp catfish queue all</pullquote> in the <pullquote>web/app/plugins/agreable-catfish-importer-plugin</pullquote> folder.
+</p>
 <form>
   <label for="category">Category:</label>
   <select name='category' id='category'>

--- a/tests/features/bootstrap/SyncContext.php
+++ b/tests/features/bootstrap/SyncContext.php
@@ -22,6 +22,7 @@ define('BEHAT_ERROR_REPORTING', E_ERROR | E_WARNING | E_PARSE);
 class SyncContext extends BehatContext {
 
   // Protected variables for the tests to use
+  protected static $escapedUrlPath;
   protected static $queueID;
   protected static $queueItem;
   protected static $queueActionResponse;
@@ -56,6 +57,23 @@ class SyncContext extends BehatContext {
     $posts = $query->get_posts();
 
     Assert::assertEquals(0, count($posts));
+  }
+
+  /**
+   * @Given /^I escape the API url path "([^"]*)"$/
+   */
+  public function iEscapeTheApiUrlPath($originalJsonUrl)
+  {
+    // Escape the url path using this handy helper
+    self::$escapedUrlPath = Sync::escapeAPIUrlPaths($originalJsonUrl);
+  }
+
+  /**
+   * @Then /^The returned url should be valid$/
+   */
+  public function theReturnedUrlShouldNotContainAnySpecialCharacters()
+  {
+    Assert::assertEquals(self::$escapedUrlPath, "http://www.shortlist.com/entertainment/films/15-things-you-probably-didnt-know-about-L%C3%A9on.json");
   }
 
   /**

--- a/tests/features/sync.feature
+++ b/tests/features/sync.feature
@@ -10,7 +10,7 @@ Feature: Sync
 
   Scenario: Escape an API url path
     Given I escape the API url path "http://www.shortlist.com/entertainment/films/15-things-you-probably-didnt-know-about-Léon.json"
-    Then The returned url shouldnt contain any special characters
+    Then The returned url should be valid
 
 
   Scenario: Queue a single post for import

--- a/tests/features/sync.feature
+++ b/tests/features/sync.feature
@@ -8,6 +8,11 @@ Feature: Sync
     Then I should have no automated_testing posts
 
 
+  Scenario: Escape an API url path
+    Given I escape the API url path "http://www.shortlist.com/entertainment/films/15-things-you-probably-didnt-know-about-Léon.json"
+    Then The returned url shouldnt contain any special characters
+
+
   Scenario: Queue a single post for import
     Given I purge the queue
     And I delete all automated_testing posts


### PR DESCRIPTION
Multiple bug fixes including, Importer Bug: Worker running actions multiple times. Make the wp queue all and queue categories run inline, they take too long for Amazon SQS and it keeps running twice. 	Make the wp queue all and queue categories run inline, they take too 	Make the wp queue all and queue categories run inline, they take too