### PR TITLE
Correctly Store ACF Fields on Importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ When running ```wp``` in the command line from this directory a couple of new co
 
 ### Queue commands
 
-The queue commands offer direct access to pushing single or multiple posts into queue.
+The queue commands offer direct access to pushing single or multiple posts into queue. It also supports an onExistAction attribute which selects how to handle existing posts in the database. By default the importer will update posts in place.
 
 ```
 wp catfish queue http://www.shortlist.com/entertainment/the-toughest-world-record-ever-has-been-broken
+wp catfish queue http://www.shortlist.com/entertainment/the-toughest-world-record-ever-has-been-broken skip
+wp catfish queue http://www.shortlist.com/entertainment/the-toughest-world-record-ever-has-been-broken delete-insert
 wp catfish queue all
 wp catfish queue http://www.shortlist.com/sitemap/entertainment/48-hours-to.xml
 ```

--- a/app/Services/Post.php
+++ b/app/Services/Post.php
@@ -165,6 +165,21 @@ class Post {
       'catfish_importer_date_updated' => $currentDate
     );
 
+    // Create meta array for new post (Data that's not in the core post_fields)
+    $postACFMetaArrayForWordpress = array(
+      'basic_short_headline' => $postObject->shortHeadline,
+      'basic_sell' => $sell,
+      'basic_header_type' => 'standard-hero',
+      'basic_header_display_headline' => true,
+      'basic_header_display_sell' => true,
+      'article_catfish_importer_url' => $postUrl,
+      'article_catfish_importer_imported' => true,
+      'article_catfish_importer_post_date' => $displayDate,
+      'article_catfish_importer_date_updated' => $currentDate
+    );
+
+
+
     // Log the created time if this is the first time this post was imported
     if($existingPost == false || $existingPost && $onExistAction == 'delete-insert') {
       $postMetaArrayForWordpress['catfish_importer_date_created'] = $currentDate;
@@ -212,6 +227,7 @@ class Post {
 
     // Save the post meta data (Any field that's not post_)
     self::setPostMetadata($wpPostId, $postMetaArrayForWordpress);
+    self::setACFPostMetadata($wpPostId, $postACFMetaArrayForWordpress);
 
     // XXX: Actions to take place __after__ the post is saved and require either the Post ID or TimberPost object
 
@@ -277,14 +293,34 @@ class Post {
   protected static function setPostMetaProperty($postId, $fieldName, $value = '') {
     if ( empty( $value ) OR ! $value ) {
       // Switch to acf api rather than WP api here...
+      delete_post_meta( $postId, $fieldName );
+    } elseif ( ! get_post_meta( $postId, $fieldName ) ) {
+      add_post_meta( $postId, $fieldName, $value );
+    } else {
+      update_post_meta( $postId, $fieldName, $value );
+    }
+  }
+
+  /**
+   * ACF Set or update multiple post meta properties at once
+   */
+  protected static function setACFPostMetadata($postId, $fields) {
+    foreach ($fields as $fieldName => $value) {
+      self::setPostMetaProperty($postId, $fieldName, $value);
+    }
+  }
+
+  /**
+   * ACF Create or update a post meta field
+   */
+  protected static function setACFPostMetaProperty($postId, $fieldName, $value = '') {
+    if ( empty( $value ) OR ! $value ) {
+      // Switch to acf api rather than WP api here...
       delete_field( $fieldName, $value, $postId );
-      // delete_post_meta( $postId, $fieldName );
     } elseif ( ! get_post_meta( $postId, $fieldName ) ) {
       update_field( $fieldName, $value, $postId );
-      // add_post_meta( $postId, $fieldName, $value );
     } else {
       update_field( $fieldName, $value, $postId );
-      // update_post_meta( $postId, $fieldName, $value );
     }
   }
 

--- a/app/Services/Sync.php
+++ b/app/Services/Sync.php
@@ -257,17 +257,18 @@ class Sync {
       if($cli) {
         WP_CLI::error($log_identifier."Error importing post from url using Posts class. " . $e->getMessage());
       }
+
       // Send handled error to BugSnag as well..
-      $this->get('bugsnag')
-        ->setReleaseStage(WP_ENV)
-        ->setMetaData([
+      $bugsnag = \Bugsnag\Client::make(getenv('BUGSNAG_API_KEY'));
+      $bugsnag->setReleaseStage(WP_ENV);
+      // Pass the post that is seeing this error
+      $bugsnag->setMetaData([
           'log_identifier' => $log_identifier // Pass the error with
         ]);
-      $bugsnag = \Bugsnag\Client::make(getenv('BUGSNAG_API_KEY'));
       $bugsnag->notifyException($e);
       if(WP_ENV == 'development') { die($e->getMessage); }
 
-      // TODO: Delete partial post if a post has been created...
+      // Could delete partial post if a post has been created here...
 
     }
   }

--- a/app/cli.php
+++ b/app/cli.php
@@ -74,6 +74,9 @@ WP_CLI::add_command('catfish testexception', 'testException');
  * [<post-url>...]
  * : One or more post url to add to the import queue.
  *
+ * [<on-exist-action>...]
+ * : Optional action if the post exists in Wordpress
+ *
  * ## EXAMPLES
  *
  *     # Add all a specified post
@@ -99,17 +102,19 @@ function addToQueue(array $args) {
     return;
   }
 
-  if(isset($args[2]) && !in_array($args[2], array('update', 'delete-insert', 'skip'))) {
+  if(isset($args[1]) && !in_array($args[1], array('update', 'delete-insert', 'skip'))) {
     WP_CLI::error("The on Exist Action must be either 'update', 'delete-insert', 'skip'");
     return;
   }
 
   // Set the onExistAction
-  if(isset($args[2])) {
-    $onExistAction = $args[2];
+  if( isset($args[1]) && in_array($args[1], array('update', 'delete-insert', 'skip')) ) {
+    $onExistAction = $args[1];
   } else {
     $onExistAction = 'update';
   }
+
+  WP_CLI::line('onExistAction set to: '.$onExistAction);
 
   if($args[0] == 'all' || strstr($args[0], '.xml')) {
     WP_CLI::line('Queueing category.');

--- a/app/cli.php
+++ b/app/cli.php
@@ -77,7 +77,7 @@ WP_CLI::add_command('catfish testexception', 'testException');
  * ## EXAMPLES
  *
  *     # Add all a specified post
- *     wp catfish queue http://www.shortlist.com/entertainment/the-toughest-world-record-ever-has-been-broken
+ *     wp catfish queue http://www.shortlist.com/entertainment/the-toughest-world-record-ever-has-been-broken update
  *
  *     # Import a category of posts
  *     wp catfish queue http://www.shortlist.com/sitemap/entertainment/48-hours-to.xml
@@ -99,18 +99,30 @@ function addToQueue(array $args) {
     return;
   }
 
+  if(isset($args[2]) && !in_array($args[2], array('update', 'delete-insert', 'skip'))) {
+    WP_CLI::error("The on Exist Action must be either 'update', 'delete-insert', 'skip'");
+    return;
+  }
+
+  // Set the onExistAction
+  if(isset($args[2])) {
+    $onExistAction = $args[2];
+  } else {
+    $onExistAction = 'update';
+  }
+
   if($args[0] == 'all' || strstr($args[0], '.xml')) {
     WP_CLI::line('Queueing category.');
 
     // Queue action is too long to run without being released back into the queue.
     // Instead run all large queue adds on the command line
-    Sync::importCategory('', array('url' => $args[0], 'onExistAction' => 'update'), true);
+    Sync::importCategory('', array('url' => $args[0], 'onExistAction' => $onExistAction), true);
 
     WP_CLI::success('Queued: ' . $args[0]);
   } else {
     WP_CLI::line('Queueing post.');
 
-    Sync::queueUrl($args[0]); // TODO: Handle onExistAction
+    Sync::queueUrl($args[0], $onExistAction);
 
     WP_CLI::success('Queued: ' . $args[0]);
   }


### PR DESCRIPTION
Fixes these tickets:

 - Instant Articles Widget Error - https://trello.com/c/ELzwuXAr/147-3-instant-articles-widget-error-3
 - Missing ACF fields on WP API - https://trello.com/c/BIZB6Fih/74-5-missing-acf-fields-on-wp-api-5
 - Conflict between Importer and Instant Articles plugin - https://trello.com/c/j3vsa5rG/75-3-conflict-between-importer-and-instant-articles-plugin-5